### PR TITLE
Allow console to run /drivebackup commands

### DIFF
--- a/DriveBackup/pom.xml
+++ b/DriveBackup/pom.xml
@@ -10,6 +10,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/DriveBackup/src/main/java/ratismal/drivebackup/handler/CommandHandler.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/handler/CommandHandler.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitScheduler;
 
@@ -44,8 +45,8 @@ public class CommandHandler implements CommandExecutor {
      * @return whether the command was handled
      */
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        if (!(sender instanceof Player)) {
-            MessageUtil.sendMessage(sender, "DriveBackupV2 only supports commands sent in-game");
+        if (!(sender instanceof Player || sender instanceof ConsoleCommandSender)) {
+            MessageUtil.sendMessage(sender, "Please run DriveBackupV2 through console or in game.");
             return true;
         }
         


### PR DESCRIPTION
An issue I face while working with DriveBackupV2 is the inability to run commands as console, since I do a large amount of work through a web control panel that gives me direct console access to my server.

This patch modifies the check to allow console to use `/drivebackup` commands.  All functionality is identical to running these commands as a player.  Linking, backups, config reloads, etc.