### PR TITLE
Console / Player Message Update

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
@@ -485,7 +485,9 @@ public class UploadThread implements Runnable {
 
         switch (backupStatus) {
             case COMPRESSING: backupStatusMessage.append("Compressing ");
+                break;
             case UPLOADING: backupStatusMessage.append("Uploading ");
+                break;
             default:
         }
 


### PR DESCRIPTION
Added break; lines to both cases within the backupStatus switch of the getBackupStatus() method so as to have intended string output when prompting the /drivebackup status command.