### PR TITLE
Fix bug in Timer.getUploadTimeMessage

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/DriveBackup.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/DriveBackup.java
@@ -308,8 +308,8 @@ public class DriveBackup extends JavaPlugin {
 
             backupTasks.add(taskScheduler.runTaskTimerAsynchronously(
                 getInstance(), 
-                new UploadThread(), 
-                Config.getBackupDelay() * 60 * 20, 
+                new UploadThread(),
+                Config.getBackupDelay() * 60 * 20,
                 Config.getBackupDelay() * 60 * 20
             ).getTaskId());
 
@@ -384,8 +384,7 @@ public class DriveBackup extends JavaPlugin {
         }
     }
 
-    /**
-     * Adds a Object to an ArrayList, if it doesn't already contain the Object
+    /**mysqlUploader, if it doesn't already contain the Object
      * @param list the ArrayList
      * @param item the Object
      */

--- a/DriveBackup/src/main/java/ratismal/drivebackup/Uploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/Uploader.java
@@ -1,0 +1,10 @@
+package ratismal.drivebackup.uploader;
+
+import net.kyori.text.TextComponent;
+
+public interface Uploader {
+    public String getName();
+    public TextComponent getSetupInstructions();
+    public boolean isErrorWhileUploading();
+    public void uploadFile(java.io.File file, String type) throws Exception;
+}

--- a/DriveBackup/src/main/java/ratismal/drivebackup/ftp/FTPUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/ftp/FTPUploader.java
@@ -4,8 +4,12 @@ import org.apache.commons.net.ftp.FTP;
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPSClient;
+import org.bukkit.ChatColor;
+
+import net.kyori.text.TextComponent;
 import ratismal.drivebackup.config.Config;
 import ratismal.drivebackup.util.MessageUtil;
+import ratismal.drivebackup.uploader.Uploader;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -18,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  * Created by Ratismal on 2016-03-30.
  */
 
-public class FTPUploader {
+public class FTPUploader implements Uploader {
     private FTPClient ftpClient;
     private SFTPUploader sftpClient;
 
@@ -265,6 +269,24 @@ public class FTPUploader {
      */
     public boolean isErrorWhileUploading() {
         return this._errorOccurred;
+    }
+
+    /**
+     * Gets the name of this upload service
+     * @return name of upload service
+     */
+    public String getName()
+    {
+        return "(S)FTP";
+    }
+
+    /**
+     * Gets the setup instructions for this uploaders
+     * @return a TextComponent explaining how to set up this uploader
+     */
+    public TextComponent getSetupInstructions()
+    {
+        return TextComponent.of("Failed to backup to the (S)FTP server, please check the server credentials in the " + ChatColor.GOLD + "config.yml");
     }
 
     /**

--- a/DriveBackup/src/main/java/ratismal/drivebackup/ftp/SFTPUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/ftp/SFTPUploader.java
@@ -3,6 +3,7 @@ package ratismal.drivebackup.ftp;
 import ratismal.drivebackup.DriveBackup;
 import ratismal.drivebackup.config.Config;
 import ratismal.drivebackup.util.MessageUtil;
+import ratismal.drivebackup.uploader.Uploader;
 
 import java.io.File;
 import java.io.FileInputStream;

--- a/DriveBackup/src/main/java/ratismal/drivebackup/googledrive/GoogleDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/googledrive/GoogleDriveUploader.java
@@ -20,9 +20,12 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
+
+import net.kyori.text.TextComponent;
 import ratismal.drivebackup.DriveBackup;
 import ratismal.drivebackup.config.Config;
 import ratismal.drivebackup.util.MessageUtil;
+import ratismal.drivebackup.uploader.Uploader;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -41,7 +44,7 @@ import org.json.JSONObject;
  * Created by Ratismal on 2016-01-20.
  */
 
-public class GoogleDriveUploader {
+public class GoogleDriveUploader implements Uploader {
     private boolean errorOccurred;
     private String refreshToken;
 
@@ -330,6 +333,36 @@ public class GoogleDriveUploader {
     public boolean isErrorWhileUploading() {
         return this.errorOccurred;
     }
+
+    /**
+     * Gets the name of this upload service
+     * @return name of upload service
+     */
+    public String getName()
+    {
+        return "Google Drive";
+    }
+
+    /**
+     * Gets the setup instructions for this uploaders
+     * @return a TextComponent explaining how to set up this uploader
+     */
+    public TextComponent getSetupInstructions()
+    {
+        return TextComponent.builder()
+                    .append(
+                        TextComponent.of("Failed to backup to Google Drive, please run ")
+                        .color(TextColor.DARK_AQUA)
+                    )
+                    .append(
+                        TextComponent.of("/drivebackup linkaccount googledrive")
+                        .color(TextColor.GOLD)
+                        .hoverEvent(HoverEvent.showText(TextComponent.of("Run command")))
+                        .clickEvent(ClickEvent.runCommand("/drivebackup linkaccount googledrive"))
+                    )
+                    .build();
+    }
+
 
     /**
      * Creates a folder with the specified name in the specified parent folder in the authenticated user's Google Drive

--- a/DriveBackup/src/main/java/ratismal/drivebackup/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/onedrive/OneDriveUploader.java
@@ -16,10 +16,12 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import net.kyori.text.TextComponent;
 import ratismal.drivebackup.DriveBackup;
 import ratismal.drivebackup.config.Config;
 import ratismal.drivebackup.util.HttpLogger;
 import ratismal.drivebackup.util.MessageUtil;
+import ratismal.drivebackup.uploader.Uploader;
 
 import java.io.*;
 import java.text.DecimalFormat;
@@ -33,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Created by Redemption on 2/24/2016.
  */
-public class OneDriveUploader {
+public class OneDriveUploader implements Uploader {
     private boolean errorOccurred;
     private long totalUploaded;
     private long lastUploaded;
@@ -337,6 +339,36 @@ public class OneDriveUploader {
     public boolean isErrorWhileUploading() {
         return this.errorOccurred;
     }
+
+    /**
+     * Gets the name of this upload service
+     * @return name of upload service
+     */
+    public String getName()
+    {
+        return "OneDrive";
+    }
+
+    /**
+     * Gets the setup instructions for this uploaders
+     * @return a TextComponent explaining how to set up this uploader
+     */
+    public TextComponent getSetupInstructions()
+    {
+        return TextComponent.builder()
+                    .append(
+                        TextComponent.of("Failed to backup to OneDrive, please run ")
+                        .color(TextColor.DARK_AQUA)
+                    )
+                    .append(
+                        TextComponent.of("/drivebackup linkaccount onedrive")
+                        .color(TextColor.GOLD)
+                        .hoverEvent(HoverEvent.showText(TextComponent.of("Run command")))
+                        .clickEvent(ClickEvent.runCommand("/drivebackup linkaccount onedrive"))
+                    )
+                    .build();
+    }
+
 
     /**
      * Creates a folder with the specified name in the specified parent folder in the authenticated user's OneDrive

--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/Timer.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/Timer.java
@@ -2,6 +2,8 @@ package ratismal.drivebackup.util;
 
 import java.io.File;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.Date;
 
 /**
@@ -43,11 +45,13 @@ public class Timer {
      */
     public String getUploadTimeMessage(File file) {
         DecimalFormat df = new DecimalFormat("#.##");
-        double difference = getTime();
-        double length = Double.valueOf(df.format(difference / 1000));
-        double speed = Double.valueOf(df.format((file.length() / 1024) / length));
+        df.setDecimalFormatSymbols(DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
-        return "File uploaded in " + length + " seconds (" + speed + "KB/s)";
+        double difference = getTime();
+        double length = difference / 1000;
+        double speed = (file.length() / 1024) / length;
+        
+        return "File uploaded in " + df.format(length) + " seconds (" + df.format(speed) + "KB/s)";
     }
 
     /**


### PR DESCRIPTION
On some system configurations, the DecimalFormat uses a comma instead of a period as a decimal seperator and the casting to double failed. 
The unnecessary casting back and forth has been removed and DecimalFormat has been set to use periods to ensure consistency in the logs.

This edit has been discussed on the Discord already (I'm the one that proposed it).

This bug prevented the deletion of old backups, so that will be working again with this PR.