### PR TITLE
Add globbing feature to backup-list

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
@@ -7,6 +7,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.text.DateFormat;
@@ -15,6 +17,8 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.Deflater;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -243,6 +247,25 @@ public class FileUtil {
                 generateFileList(new File(file, filename), inputFolderPath);
             }
         }
+    }
+
+    /**
+     * Finds all folders that match a glob
+     * @param glob the glob to search
+     * @param rootPath the path to start searching from
+     * @return List of all folders that match this glob under rootPath
+     */
+    public static List<Path> generateGlobFolderList(String glob, String rootPath) {
+        PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:./" + glob);
+        List<Path> list = new ArrayList<Path>();
+        try (Stream<Path> walk = Files.walk(Path.of(rootPath))) {
+            list = walk.filter(pathMatcher::matches).collect(Collectors.toList());
+        } catch (IOException e) {
+            //TODO: log exeption somewhere
+            MessageUtil.sendConsoleMessage(e.toString());
+            return list;
+        }
+        return list;
     }
 
     /**

--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
@@ -259,7 +259,7 @@ public class FileUtil {
         PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:./" + glob);
         List<Path> list = new ArrayList<Path>();
         try (Stream<Path> walk = Files.walk(Path.of(rootPath))) {
-            list = walk.filter(pathMatcher::matches).collect(Collectors.toList());
+            list = walk.filter(pathMatcher::matches).filter(Files::isDirectory).collect(Collectors.toList());
         } catch (IOException e) {
             //TODO: log exeption somewhere
             MessageUtil.sendConsoleMessage(e.toString());


### PR DESCRIPTION
With this PR the `backup-list` supports globbing like this:

```
backup-list:
- glob: "world*"
  format: "'Backup-world-'yyyy-M-d--HH-mm'.zip'"
  create: true
```
Notice the parameter is called `glob` instead of `path`.

This would match all folders in the root directory starting with "world", such as `world`, `world_nether` and `world_the_end`. In that case, the above config would be equivalent to:
```
backup-list:
- path: "world"
  format: "'Backup-world-'yyyy-M-d--HH-mm'.zip'"
  create: true
- path: "world_nether"
  format: "'Backup-world-'yyyy-M-d--HH-mm'.zip'"
  create: true
- path: "world_the_end"
  format: "'Backup-world-'yyyy-M-d--HH-mm'.zip'"
  create: true
```
This means that each matches folder will be saved in its own directory in the `destination` folder and not combined into one zip. This is intended as I think it fits better with the overall design of the plugin.

There should not be a lot of issues with this because the glob is internally expanded to a list of folders that match this glob and then the backup is done with the same code as for the single folder back-ups.

Currently, if both `glob` and `path` are present in the config, it simply ignores the `path` and uses the `glob`. This is to ensure backwards compatibility, so that it's possible to leave the path configuration in the config and if the plugin version does not support globbing, it will simply choose the path but if it supports globbing it will choose the glob.