### PR TITLE
Hacky fix for upstream adventure-text-minimessage change d0a7e0e

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/MessageUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/MessageUtil.java
@@ -1,8 +1,10 @@
 package ratismal.drivebackup.util;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.bukkit.Bukkit;
@@ -14,7 +16,9 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
 import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
+import net.kyori.adventure.text.minimessage.placeholder.Replacement;
 import ratismal.drivebackup.config.ConfigParser;
 import ratismal.drivebackup.config.ConfigParser.Config;
 import ratismal.drivebackup.plugin.DriveBackup;
@@ -66,7 +70,20 @@ public class MessageUtil {
      * @return the calling MessageUtil's instance
      */
     public MessageUtil mmText(String text, String... placeholders) {
-        message.add(MiniMessage.miniMessage().deserialize("<dark_aqua>" + text, PlaceholderResolver.resolving(placeholders)));
+        int size = placeholders.length;
+        final Map<String, Replacement<?>> plmap = new HashMap<>(size/2);
+
+        String key = null;
+        for (int i = 0; i < size; i++) {
+            if (key == null) {
+                key = placeholders[i];
+            } else {
+                plmap.put(key, Replacement.miniMessage(placeholders[i]));
+            }
+
+        }
+
+        message.add(MiniMessage.miniMessage().deserialize("<dark_aqua>" + text, PlaceholderResolver.map(plmap)));
         return this;
     }
 
@@ -77,7 +94,7 @@ public class MessageUtil {
      * @return the calling MessageUtil's instance
      */
     public MessageUtil mmText(String text, String title, Component content) {
-        message.add(MiniMessage.miniMessage().deserialize("<dark_aqua>" + text, PlaceholderResolver.resolving(title, content)));
+        message.add(MiniMessage.miniMessage().deserialize("<dark_aqua>" + text, PlaceholderResolver.placeholders(Placeholder.component(title, content))));
         return this;
     }
 

--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/MessageUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/MessageUtil.java
@@ -79,6 +79,7 @@ public class MessageUtil {
                 key = placeholders[i];
             } else {
                 plmap.put(key, Replacement.miniMessage(placeholders[i]));
+                key = null;
             }
 
         }


### PR DESCRIPTION
This is probably not the right way to do this, but it allows the plugin to build again

See https://github.com/KyoriPowered/adventure/pull/632 for the relevant upstream changes