### PR TITLE
Added %NAME

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
@@ -51,14 +51,14 @@ public class FileUtil {
 
                 String fileName = file.getName();
 
-                try {
-                    ZonedDateTime date = formatter.parse(fileName);
-                    backupList.put(date.toEpochSecond(), file);
-                } catch (Exception e) {
+                // try {
+                //     ZonedDateTime date = formatter.parse(fileName);
+                //     backupList.put(date.toEpochSecond(), file);
+                // } catch (Exception e) {
                     // Fallback to using file creation date if the file name doesn't match the format
                     backupList.put((file.lastModified() / 1000), file);
-                    logger.log(intl("local-backup-date-format-invalid"), "file-name", fileName);
-                }
+                //     logger.log(intl("local-backup-date-format-invalid"), "file-name", fileName);
+                // }
             }
         }
 
@@ -122,7 +122,18 @@ public class FileUtil {
                 intl("local-backup-in-backup-folder"), 
                 "files-in-backup-folder-count", String.valueOf(filesInBackupFolder));
         }
+        // Get the name of the last folder in the location path
+        String lastFolderName = "";
+        int lastSeparatorIndex = location.lastIndexOf('/');
+        if (lastSeparatorIndex != -1) {
+            lastFolderName = location.substring(lastSeparatorIndex + 1);
+        }
 
+        // Replace the placeholder %NAME with the last folder name in the file name
+        String placeholder = "%NAME";
+        if (fileName.contains(placeholder)) {
+            fileName = fileName.replace(placeholder, lastFolderName);
+        }
         zipIt(location, path.getPath() + "/" + fileName, fileList);
     }
 

--- a/DriveBackup/src/main/resources/config.yml
+++ b/DriveBackup/src/main/resources/config.yml
@@ -20,7 +20,7 @@ backup-schedule-list:
 
 backup-list:
 - glob: "world*"
-  format: "Backup-world-%FORMAT.zip"
+  format: "Backup-%NAME-%FORMAT.zip"
   create: true
 - path: "plugins"
   format: "Backup-plugins-%FORMAT.zip"


### PR DESCRIPTION
### What is this change?
Added the possibility of automatically renaming the backup file for the globs with the name of the respective folder.
Changes:
- Update FileUtil.java to replace %NAME for the name of the folder that is going to be backup when using a glob setting
- Added %NAME in glob example in config file
### Example
Example config:
```
backup-list:
- glob: "world*"
  format: "Backup-%NAME-%FORMAT.zip"
  create: true
```
In a default Minecraft server the previous config will produce 3 backup files with the following names:
Backup-world-2023-7-31--22-06.zip
Backup-world_nether-2023-7-31--22-06.zip
Backup-world_the_end-2023-7-31--22-06.zip
### Tested?
This was tested using OneDrive and works as expected. Using latest Paper (1.20.1 build #100)
### Warning
This does **NOT** work as expected in non-glob form "path"
Example of **NON** proper usage:
```
- path: "plugins"
  format: "Backup-%NAME-%FORMAT.zip"
  create: true
```
The previous config will create the following file:
Backup--2023-7-31--22-06.zip
Note that the expected "plugins" name is **missing.**