### PR TITLE
Fix Reversed Auto-Save Option

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/ServerUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/ServerUtil.java
@@ -11,7 +11,7 @@ public class ServerUtil {
      * @param autoSave whether to save automatically
      */
     public static void setAutoSave(boolean autoSave) {
-        if (!ConfigParser.getConfig().backupStorage.disableSavingDuringBackups) {
+        if (ConfigParser.getConfig().backupStorage.disableSavingDuringBackups) {
             return;
         }
 


### PR DESCRIPTION
It seems that currently, worlds are saved even if other plugins disable world auto save if `disable-saving-during-backups` is set to true. I believe this fixes the issue - the option is currently reversed.