### PR TITLE
retain file timestamps in zip

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
@@ -198,9 +198,8 @@ public class FileUtil {
                     fileAttributes = Files.readAttributes(Paths.get(filePath), BasicFileAttributes.class);
                 } catch(Exception e) { }
                 if (fileAttributes == null) {
-                    // TODO intl
                     logger.info(
-                        intl("Failed to read attributes for \"<file-path>\". Do you have permission to access it?"),
+                        intl("local-backup-failed-attributes"),
                         "file-path", filePath);
                 } else {
                     entry.setCreationTime(fileAttributes.creationTime());

--- a/DriveBackup/src/main/resources/intl.yml
+++ b/DriveBackup/src/main/resources/intl.yml
@@ -176,6 +176,7 @@ local-backup-backlisted: 'Didn''t include <blacklisted-files-count> file(s) in
 local-backup-date-format-invalid: |-
   Unable to parse date format of stored backup "<file-name>", this can be due to the date format being updated in the config.yml
   Backup will be the first deleted
+local-backup-failed-attributes: 'Failed to read attributes for "<file-path>", using defaults instead. Do you have permission to access it?'
 local-backup-failed-permissions: |-
   Failed to create local backup, plugin does not have permission to write to the required file system location
   Even if local-keep-count is set to zero, the plugin needs to temporarily create a local backup


### PR DESCRIPTION
this changes the ZipEntry creation in FileUtil.zipIt, to include the file timestamps as they are on disk, instead of using the time of the backup

_having the actual timestamps of the files can be used to quickly determine which files actually changed since the last backup, for example_