### PR TITLE
getLatest exception handling

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/plugin/updater/UpdateChecker.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/plugin/updater/UpdateChecker.java
@@ -1,6 +1,5 @@
 package ratismal.drivebackup.plugin.updater;
 
-import org.apache.http.client.HttpResponseException;
 import org.json.JSONArray;
 
 import okhttp3.Request;
@@ -93,7 +92,7 @@ public class UpdateChecker {
         JSONArray pluginVersions;
         try (Response response = DriveBackup.httpClient.newCall(request).execute()) {
             if (response.code() != 200) {
-                throw new HttpResponseException(response.code(), response.message());
+                throw new Exception("Unexpected response: " + response.code() + " : " + response.message());
             }
             pluginVersions = new JSONArray(response.body().string());
         }


### PR DESCRIPTION
this improves the exception handling in `UpdateChecker.getLatest()` by

- using try-with-resources for the response object
  - this ensures it is always being closed: `JSONArray()`, `.string()` & the new response code check can all throw before the response is able to be closed
- checking the response code before proceeding
  - this surfaces a potential error that before would have been hidden
- change `NumberFormatException` to `NoSuchElementException` with detail message
  - the exception type more closely represents the issue, with the message stating the actual issue

this is somewhat related to #141
while this does not solve that issue, it provides more & clearer error messages that may help to find the root cause

note:
I originally used `org.apache.http.client.HttpResponseException` for the return code check. but that appears to not be a direct dependency, so I replaced it with an generic exception