### PR TITLE
improve %NAME replacement, to work with path & glob, linux & windows

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
@@ -30,6 +30,8 @@ import static ratismal.drivebackup.config.Localization.intl;
  */
 
 public class FileUtil {
+    private static final String NAME_KEYWORD = "%NAME";
+
     private UploadLogger logger;
 
     public FileUtil(UploadLogger logger) {
@@ -110,16 +112,10 @@ public class FileUtil {
                 intl("local-backup-in-backup-folder"), 
                 "files-in-backup-folder-count", String.valueOf(filesInBackupFolder));
         }
-        // Get the name of the last folder in the location path.
-        String lastFolderName = "";
-        int lastSeparatorIndex = location.lastIndexOf('/');
-        if (lastSeparatorIndex != -1) {
-            lastFolderName = location.substring(lastSeparatorIndex + 1);
-        }
-        // Replace the placeholder %NAME with the last folder name in the file name.
-        String placeholder = "%NAME";
-        if (fileName.contains(placeholder)) {
-            fileName = fileName.replace(placeholder, lastFolderName);
+        if (fileName.contains(NAME_KEYWORD)) {
+            int lastSeparatorIndex = Math.max(location.lastIndexOf('/'), location.lastIndexOf('\\'));
+            String lastFolderName = location.substring(lastSeparatorIndex + 1);
+            fileName = fileName.replace(NAME_KEYWORD, lastFolderName);
         }
         zipIt(location, path.getPath() + "/" + fileName, fileList);
     }


### PR DESCRIPTION
this improves the replacement logic for `%NAME` in `FileUtil.makeBackup()`
- it now works correctly with both glob and path locations
- it now works under both Linux and Windows

I also took the liberty to make `"%NAME"` a static, similar to `FORMAT_KEYWORD` in `LocalDateTimeFormatter`

tested under Windows 10 and WSL Ubuntu 23