### PR TITLE
handle onedrive upload status codes

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -35,7 +35,7 @@ import static ratismal.drivebackup.config.Localization.intl;
  * Created by Redemption on 2/24/2016.
  */
 public class OneDriveUploader extends Uploader {
-    public static final int EXPONENTIAL_BACKOFF_MILLIS_DEFAULT = 1;
+    public static final int EXPONENTIAL_BACKOFF_MILLIS_DEFAULT = 1000;
     public static final int EXPONENTIAL_BACKOFF_FACTOR = 5;
     public static final int MAX_RETRY_ATTEMPTS = 3;
 
@@ -177,7 +177,7 @@ public class OneDriveUploader extends Uploader {
             }
             String uploadURL = parsedResponse.getString("uploadUrl");
             raf = new RandomAccessFile(file, "r");
-            int exponentialBackoff = EXPONENTIAL_BACKOFF_MILLIS_DEFAULT;
+            int exponentialBackoffMillis = EXPONENTIAL_BACKOFF_MILLIS_DEFAULT;
             int retryCount = 0;
             while (true) {
                 byte[] bytesToUpload = getChunk();
@@ -191,7 +191,7 @@ public class OneDriveUploader extends Uploader {
                         parsedResponse = new JSONObject(uploadResponse.body().string());
                         List<Object> nextExpectedRanges = parsedResponse.getJSONArray("nextExpectedRanges").toList();
                         setRanges(nextExpectedRanges.toArray(new String[0]));
-                        exponentialBackoff = EXPONENTIAL_BACKOFF_MILLIS_DEFAULT;
+                        exponentialBackoffMillis = EXPONENTIAL_BACKOFF_MILLIS_DEFAULT;
                         retryCount = 0;
                     } else if (uploadResponse.code() == 201 || uploadResponse.code() == 200) {
                         break;
@@ -202,8 +202,8 @@ public class OneDriveUploader extends Uploader {
                             throw new IOException(String.format("Upload failed after %d retries. %d %s", MAX_RETRY_ATTEMPTS, uploadResponse.code(), uploadResponse.message()));
                         }
                         if (uploadResponse.code() >= 500 && uploadResponse.code() < 600) {
-                            Thread.sleep(exponentialBackoff);
-                            exponentialBackoff *= EXPONENTIAL_BACKOFF_FACTOR;
+                            Thread.sleep(exponentialBackoffMillis);
+                            exponentialBackoffMillis *= EXPONENTIAL_BACKOFF_FACTOR;
                         }
                         retryCount++;
                     }

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -38,6 +38,7 @@ public class OneDriveUploader extends Uploader {
     public static final int EXPONENTIAL_BACKOFF_MILLIS_DEFAULT = 1;
     public static final int EXPONENTIAL_BACKOFF_FACTOR = 5;
     public static final int MAX_RETRY_ATTEMPTS = 3;
+
     private UploadLogger logger;
     
     private long totalUploaded;
@@ -170,11 +171,11 @@ public class OneDriveUploader extends Uploader {
                 .url("https://graph.microsoft.com/v1.0/me/drive/root:/" + folder.getPath() + "/" + file.getName() + ":/createUploadSession")
                 .post(RequestBody.create("{}", jsonMediaType))
                 .build();
-            Response response = DriveBackup.httpClient.newCall(request).execute();
-            JSONObject parsedResponse = new JSONObject(response.body().string());
-            response.close();
+            JSONObject parsedResponse;
+            try (Response response = DriveBackup.httpClient.newCall(request).execute()) {
+                parsedResponse = new JSONObject(response.body().string());
+            }
             String uploadURL = parsedResponse.getString("uploadUrl");
-            //Assign our backup to Random Access File
             raf = new RandomAccessFile(file, "r");
             int exponentialBackoff = EXPONENTIAL_BACKOFF_MILLIS_DEFAULT;
             int retryCount = 0;
@@ -188,8 +189,8 @@ public class OneDriveUploader extends Uploader {
                 try (Response uploadResponse = DriveBackup.httpClient.newCall(request).execute()) {
                     if (uploadResponse.code() == 202) {
                         parsedResponse = new JSONObject(uploadResponse.body().string());
-                        List<String> nextExpectedRanges = (List<String>) (Object) parsedResponse.getJSONArray("nextExpectedRanges").toList();
-                        setRanges(nextExpectedRanges.toArray(new String[nextExpectedRanges.size()]));
+                        List<Object> nextExpectedRanges = parsedResponse.getJSONArray("nextExpectedRanges").toList();
+                        setRanges(nextExpectedRanges.toArray(new String[0]));
                         exponentialBackoff = EXPONENTIAL_BACKOFF_MILLIS_DEFAULT;
                         retryCount = 0;
                     } else if (uploadResponse.code() == 201 || uploadResponse.code() == 200) {

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -194,10 +194,11 @@ public class OneDriveUploader extends Uploader {
                         retryCount = 0;
                     } else if (uploadResponse.code() == 201 || uploadResponse.code() == 200) {
                         break;
-                    } else {
+                    } else { // conflict after successful upload not handled
                         if (retryCount > MAX_RETRY_ATTEMPTS) {
-                            // TODO cancel
-                            throw new IOException("Too many retries");
+                            request = new Request.Builder().url(uploadURL).delete().build();
+                            DriveBackup.httpClient.newCall(request).execute().close();
+                            throw new IOException(String.format("Upload failed after %d retries. %d %s", MAX_RETRY_ATTEMPTS, uploadResponse.code(), uploadResponse.message()));
                         }
                         if (uploadResponse.code() >= 500 && uploadResponse.code() < 600) {
                             Thread.sleep(exponentialBackoff);


### PR DESCRIPTION
resolves #154 _(hopefully, hard to test for such an uncommon error)_

ideally there would be a way to test against some dummy api, are you aware of something like that?

information about status codes i pulled from [here](https://learn.microsoft.com/en-us/graph/api/driveitem-createuploadsession?view=graph-rest-1.0)

it will now use the status code of the response to decide on how to proceed
on failure it will retry up to 3 times, depending on the error code with exponential backup as recommended by MS docs _(see link above)_

changes have been tested on windows

_one a semi related note, why wasn't the [Microsoft Graph SDK](https://learn.microsoft.com/en-us/graph/sdks/sdks-overview) used, similar to the other uploaders?_