### PR TITLE
prevent excess quotes in ofPattern

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/LocalDateTimeFormatter.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/LocalDateTimeFormatter.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
 
 public final class LocalDateTimeFormatter {
     private static final String FORMAT_KEYWORD = "%FORMAT";
+    private static final String FORMAT_REPLACEMENT = "'yyyy-M-d--HH-mm'";
     private static final Pattern VALID_FORMAT = Pattern.compile("^[\\w\\-.'% ]+$");
 
     private final DateTimeFormatter formatter;
@@ -23,15 +24,13 @@ public final class LocalDateTimeFormatter {
     @Contract ("_ -> new")
     public static LocalDateTimeFormatter ofPattern(String pattern) throws IllegalArgumentException {
         verifyPattern(pattern);
-        StringBuilder finalPatternBuilder = new StringBuilder(pattern);
-        // Escape non-date format characters, if user specified %FORMAT in the pattern.
         if (pattern.contains(FORMAT_KEYWORD)) {
-            finalPatternBuilder.insert(0, "'");
-            finalPatternBuilder.append("'");
+            int frontOffset = pattern.startsWith(FORMAT_KEYWORD) ? 2 : 0;
+            int backOffset = pattern.endsWith(FORMAT_KEYWORD) ? 2 : 0;
+            pattern = "'" + pattern.replace(FORMAT_KEYWORD, FORMAT_REPLACEMENT) + "'";
+            pattern = pattern.substring(frontOffset, pattern.length() - backOffset);
         }
-        String finalPattern = finalPatternBuilder.toString();
-        finalPattern = finalPattern.replaceAll(Pattern.quote(FORMAT_KEYWORD), "'yyyy-M-d--HH-mm'");
-        return new LocalDateTimeFormatter(DateTimeFormatter.ofPattern(finalPattern));
+        return new LocalDateTimeFormatter(DateTimeFormatter.ofPattern(pattern));
     }
 
     public String format(@NotNull ZonedDateTime timeDate) {


### PR DESCRIPTION
this prevents excess quotes from appearing in the format string after replacement if `%FORMAT` is at the front and/or back of the pattern (see first 4 examples in table below)

this was originally part of #152 but the `%NAME` handling has since been solved separately, so i decided to extract that functionality



| pattern           | current                         | this                            |
| ----------------- | ------------------------------- | ------------------------------- |
| %FORMAT           | '2024-4-1--10-45'               | 2024-4-1--10-45                 |
| %FORMATHH         | '2024-4-1--10-45HH              | 2024-4-1--10-45HH               |
| mm%FORMAT         | mm2024-4-1--10-45'              | mm2024-4-1--10-45               |
| %NAME%FORMAT      | %NAME2024-4-1--10-45'           | %NAME2024-4-1--10-45            |
| mm%FORMATHH       | mm2024-4-1--10-45HH             | mm2024-4-1--10-45HH             |
| mm%NAMEM%FORMATHH | mm%NAMEM2024-4-1--10-45HH       | mm%NAMEM2024-4-1--10-45HH       |
| YYYY-MM-dd-HH     | 2024-04-01-10                   | 2024-04-01-10                   |
| 'text'            | text                            | text                            |
| 'text'HH          | text10                          | text10                          |
| HH'text           | IllegalArgumentException        | IllegalArgumentException        |
| text              | IllegalArgumentException        | IllegalArgumentException        |
| mm%NAMEHH         | 45%38743919362800387439194Mon10 | 45%38743926363200387439264Mon10 |
| %NAME             | %38743927364100387439274Mon     | %38743927364100387439274Mon     |
| '%NAME'           | %NAME                           | %NAME                           |
| '%FORMAT'         | IllegalArgumentException        | IllegalArgumentException        |
| '%NAME'HH         | %NAME10                         | %NAME10                         |
| '%FORMAT'HH       | IllegalArgumentException        | IllegalArgumentException        |
| HH'%FORMAT%NAME'M | IllegalArgumentException        | IllegalArgumentException        |
