### PR TITLE
add unit test framework

### DIFF
--- a/DriveBackup/pom.xml
+++ b/DriveBackup/pom.xml
@@ -149,6 +149,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.2</version>
+            </plugin>
         </plugins>
     </build>
     <distributionManagement>
@@ -235,6 +240,18 @@
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>8.5.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.11.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/DriveBackup/src/test/java/ratismal/drivebackup/ExampleTest.java
+++ b/DriveBackup/src/test/java/ratismal/drivebackup/ExampleTest.java
@@ -1,0 +1,25 @@
+package ratismal.drivebackup;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ExampleTest {
+
+    @Test
+    void exampleWithMockito() {
+        @SuppressWarnings("unchecked")
+        List<String> mockedList = mock();
+
+        when(mockedList.get(0)).thenReturn("first");
+
+        assertEquals("first", mockedList.get(0));
+
+        assertNull(mockedList.get(999));
+    }
+}

--- a/DriveBackup/src/test/resources/junit-platform.properties
+++ b/DriveBackup/src/test/resources/junit-platform.properties
@@ -1,0 +1,4 @@
+junit.jupiter.testmethod.order.default = org.junit.jupiter.api.MethodOrderer$Random
+junit.jupiter.testclass.order.default = org.junit.jupiter.api.ClassOrderer$Random
+junit.jupiter.execution.parallel.enabled = true
+junit.jupiter.execution.parallel.mode.default = concurrent


### PR DESCRIPTION
this adds unit test support to the project through
[Maven Surefire Plugin](https://maven.apache.org/surefire/maven-surefire-plugin/index.html) (unit test execution)
[JUnit5](https://junit.org/junit5/) (unit test framework)
[Mockito](https://site.mockito.org/) (mocking framework)
so that future changes can just simply add _(unit)_ tests without needing to set everything up

i choose those 3 as they appear to the most widly used within the java eco system

the [example test](https://github.com/StillGreen-san/forkedDriveBackupV2/blob/c78f5d6ca342ceeb52622b979b8535e2c6e43c7b/DriveBackup/src/test/java/ratismal/drivebackup/ExampleTest.java) is just a placeholder to make sure everything works and to serve as a minimal example for future tests. _this can be removed once actual tests have been added later_

[junit-platform.properties](https://github.com/StillGreen-san/forkedDriveBackupV2/blob/c78f5d6ca342ceeb52622b979b8535e2c6e43c7b/DriveBackup/src/test/resources/junit-platform.properties) is setup to run all tests in parallel and random order. both to help uncover _(hidden)_ dependencies between tests _(that should not be there)_, parallel may also improve execution time _(not that unit tests should take that long to begin with)_. should the need for sequential or ordered test execution arise, there are annotations from junit to control this on a per test(class) bases [see here](https://junit.org/junit5/docs/current/user-guide/#writing-tests-test-execution-order) [and here](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution)

an additional github workflow was *not* added, as the existing [build workflow](https://github.com/MaxMaeder/DriveBackupV2/blob/master/.github/workflows/maven.yml) runs *package* which already includes the *test phase*

_one unfortunate thing with mockito is that the [mock method](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#mock_without_class) produces an unchecked warning. and based on [this 2018 issue](https://github.com/mockito/mockito/issues/1531) its not super high on their list. this could be sidestepped by have the mockobject as a class member using [@Mock](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mock.html), but that requires more boilerplate_