### PR TITLE
onedrive improvements

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/GraphApiErrorException.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/GraphApiErrorException.java
@@ -1,0 +1,114 @@
+package ratismal.drivebackup.uploaders.onedrive;
+
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * an exception representing a microsoft graph api error
+ */
+public class GraphApiErrorException extends Exception {
+    private static final String ERROR_OBJ_KEY = "error";
+    private static final String CODE_STR_KEY = "code";
+    private static final String INNERERROR_OBJ_KEY = "innererror";
+    private static final String MESSAGE_STR_KEY = "message";
+    private static final String DETAILS_ARR_KEY = "details";
+
+    /** status code of the response or -1 if not available */
+    public final int statusCode;
+    /** an error code string for the error that occurred */
+    public final String errorCode;
+    /** a developer ready message about the error that occurred. this shouldn't be displayed to the user directly */
+    public final String errorMessage;
+    /** optional list of additional error objects that might be more specific than the top-level error */
+    public final List<String> innerErrors;
+    /**
+     * optional list of additional error objects that might provide a breakdown of multiple errors encountered
+     * while processing the request
+     */
+    public final List<GraphApiErrorException> details;
+
+    /**
+     * create the exception from a response
+     *
+     * @param response to parse error from its body
+     * @throws IOException          if the body string could not be loaded
+     * @throws NullPointerException if the body could not be loaded
+     * @throws JSONException        if the body does not contain the expected json values
+     */
+    public GraphApiErrorException(@NotNull Response response) throws IOException {
+        this(response.code(), new JSONObject(response.body().string()).getJSONObject(ERROR_OBJ_KEY));
+    }
+
+    /**
+     * create the exception from a status code and response body
+     *
+     * @param statusCode of the response
+     * @param responseBody of the response
+     * @throws JSONException if the body does not contain the expected json values
+     */
+    public GraphApiErrorException(int statusCode, @NotNull String responseBody) {
+        this(statusCode, new JSONObject(responseBody).getJSONObject(ERROR_OBJ_KEY));
+    }
+
+    private static List<String> parseInnerErrors(@Nullable JSONObject innerErrors) {
+        List<String> list = new ArrayList<>();
+        while (innerErrors != null) {
+            String errorCode = innerErrors.optString(CODE_STR_KEY);
+            if (errorCode != null) {
+                list.add(errorCode);
+            }
+            innerErrors = innerErrors.optJSONObject(INNERERROR_OBJ_KEY);
+        }
+        return list;
+    }
+
+    private static List<GraphApiErrorException> parseDetails(@Nullable JSONArray details) {
+        if (details == null) {
+            return new ArrayList<>();
+        }
+        List<GraphApiErrorException> list = new ArrayList<>(details.length());
+        for (int detailIdx = 0; detailIdx < details.length(); detailIdx++) {
+            list.add(new GraphApiErrorException(-1, details.getJSONObject(detailIdx).getJSONObject(ERROR_OBJ_KEY)));
+        }
+        return list;
+    }
+
+    private GraphApiErrorException(int statusCode, @NotNull JSONObject error) {
+        this(statusCode, error.getString(CODE_STR_KEY), error.getString(MESSAGE_STR_KEY),
+            parseInnerErrors(error.optJSONObject(INNERERROR_OBJ_KEY)),
+            parseDetails(error.optJSONArray(DETAILS_ARR_KEY)));
+    }
+
+    private static String toMessage(int statusCode, String errorCode, String errorMessage, List<String> innerErrors,
+        List<GraphApiErrorException> details) {
+        String format = "%d %s : \"%s\"%s%s";
+        String inner = String.join("\", \"", innerErrors);
+        String detail = details.stream().map(GraphApiErrorException::getMessage).collect(Collectors.joining(" }, { "));
+        if (!inner.isEmpty()) {
+            inner = " inner:[ \"" + inner + "\" ]";
+        }
+        if (!detail.isEmpty()) {
+            detail = " details:[ { " + detail + " } ]";
+        }
+        return String.format(format, statusCode, errorCode, errorMessage, inner, detail);
+    }
+
+    private GraphApiErrorException(int statusCode, String errorCode, String errorMessage, List<String> innerErrors,
+        List<GraphApiErrorException> details) {
+        super(toMessage(statusCode, errorCode, errorMessage, innerErrors, details));
+        this.statusCode = statusCode;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.innerErrors = innerErrors;
+        this.details = details;
+    }
+}

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -128,7 +128,7 @@ public class OneDriveUploader extends Uploader {
     public void uploadFile(File file, String location) {
         try {
             String destinationRoot = normalizePath(ConfigParser.getConfig().backupStorage.remoteDirectory);
-            String destinationPath = concatPath(destinationRoot, location);
+            String destinationPath = concatPath(destinationRoot, normalizePath(location));
             FQID destinationId = createPath(destinationPath);
             String uploadURL = createUploadSession(file.getName(), destinationId);
             try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -499,10 +499,13 @@ public class OneDriveUploader extends Uploader {
                     retryCount = 0;
                 } else if (uploadResponse.code() == 201 || uploadResponse.code() == 200) {
                     break;
-                } else { // TODO 404 409 416
-                    if (retryCount > MAX_RETRY_ATTEMPTS) {
+                } else { // TODO 416
+                    if (retryCount > MAX_RETRY_ATTEMPTS || uploadResponse.code() == 409) {
                         Request cancelRequest = new Request.Builder().url(uploadURL).delete().build();
                         DriveBackup.httpClient.newCall(cancelRequest).execute().close();
+                        throw new GraphApiErrorException(uploadResponse);
+                    }
+                    if (uploadResponse.code() == 404) {
                         throw new GraphApiErrorException(uploadResponse);
                     }
                     if (uploadResponse.code() >= 500 && uploadResponse.code() < 600) {

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -237,20 +237,22 @@ public class OneDriveUploader extends Uploader {
     }
 
     /**
-     * removes "." and ".." segments from the path
+     * removes "." and ".." segments from the path,
+     * replaces all separators with '/',
+     * discards the first leading and trailing separator
      * @param path to normalize
-     * @return the normalized path
+     * @return the normalized relative path
      */
     @NotNull
-    private String normalizePath(@NotNull String path) {
+    private static String normalizePath(@NotNull String path) {
         StringBuilder normalized = new StringBuilder();
         for (String part : path.split("[/\\\\]")) {
-            if (".".equals(part) || "..".equals(part)) {
+            if (part.isEmpty() || ".".equals(part) || "..".equals(part)) {
                 continue;
             }
             normalized.append('/').append(part);
         }
-        return normalized.substring(1);
+        return normalized.substring(Math.min(normalized.length(), 1));
     }
 
     /**
@@ -260,12 +262,18 @@ public class OneDriveUploader extends Uploader {
      * @return joined path
      */
     @NotNull
-    private String concatPath(@NotNull String lhs, @NotNull String rhs) {
+    private static String concatPath(@NotNull String lhs, @NotNull String rhs) {
         if (rhs.isEmpty()) {
             return lhs;
         }
         if (lhs.isEmpty()) {
             return rhs;
+        }
+        if(lhs.endsWith("/")) {
+            lhs = lhs.substring(0, lhs.length() - 1);
+        }
+        if(rhs.startsWith("/")) {
+            rhs = rhs.substring(1);
         }
         return lhs + '/' + rhs;
     }

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -33,11 +33,9 @@ import static ratismal.drivebackup.config.Localization.intl;
  * Created by Redemption on 2/24/2016.
  */
 public class OneDriveUploader extends Uploader {
-    public static final int EXPONENTIAL_BACKOFF_MILLIS_DEFAULT = 1000;
-    public static final int EXPONENTIAL_BACKOFF_FACTOR = 5;
-    public static final int MAX_RETRY_ATTEMPTS = 3;
-
-    private final UploadLogger logger;
+    private static final int EXPONENTIAL_BACKOFF_MILLIS_DEFAULT = 1000;
+    private static final int EXPONENTIAL_BACKOFF_FACTOR = 5;
+    private static final int MAX_RETRY_ATTEMPTS = 3;
 
     private String accessToken = "";
     private String refreshToken;
@@ -48,6 +46,7 @@ public class OneDriveUploader extends Uploader {
     private static final MediaType jsonMediaType = MediaType.parse("application/json; charset=utf-8");
     private static final MediaType textMediaType = MediaType.parse("text/plain");
 
+    // as per ms docs should be multiple of 320 KiB (327'680 bytes)
     private static final int UPLOAD_CHUNK_SIZE = 5 * 1024 * 1024;
 
     /**
@@ -212,7 +211,7 @@ public class OneDriveUploader extends Uploader {
     /**
      * creates all folders in the path if they don't already exist
      * @param path to create the folders for
-     * @return FQID of the last folder in the path
+     * @return {@link OneDriveUploader.FQID FQID} of the last folder in the path
      * @throws IOException if the request could not be executed
      * @throws GraphApiErrorException if the folder could not be found or created
      * @throws JSONException if the response does not contain the expected items
@@ -232,7 +231,7 @@ public class OneDriveUploader extends Uploader {
      * creates a folder at the root if it doesn't already exist
      * @param root of where to create the folder
      * @param folder name to create
-     * @return FQID of the folder
+     * @return {@link OneDriveUploader.FQID FQID} of the folder
      * @throws IOException if the request could not be executed
      * @throws GraphApiErrorException if the folder could not be found or created
      * @throws JSONException if the response does not contain the expected items
@@ -264,7 +263,7 @@ public class OneDriveUploader extends Uploader {
     /**
      * creates a folder at the drive root if it doesn't already exist
      * @param folder name to create
-     * @return FQID of the folder
+     * @return {@link OneDriveUploader.FQID FQID} of the folder
      * @throws IOException if the request could not be executed
      * @throws GraphApiErrorException if the root could not be found or created
      * @throws JSONException if the response does not contain the expected items
@@ -296,7 +295,7 @@ public class OneDriveUploader extends Uploader {
     /**
      * tries to find folder in the drive root
      * @param folder to search
-     * @return FQID or null if not found
+     * @return {@link OneDriveUploader.FQID FQID} or null if not found
      * @throws IOException if the request could not be executed
      * @throws GraphApiErrorException if the root could not be retrieved
      * @throws JSONException if the response does not contain the expected items
@@ -330,7 +329,7 @@ public class OneDriveUploader extends Uploader {
      * tries to find a folder under root
      * @param root to search
      * @param folder to look for
-     * @return FQID or null if not found
+     * @return {@link OneDriveUploader.FQID FQID} or null if not found
      * @throws IOException if the request could not be executed
      * @throws GraphApiErrorException if the children could not be retrieved
      * @throws JSONException if the response does not contain the expected items
@@ -389,7 +388,7 @@ public class OneDriveUploader extends Uploader {
      * upload a file up to 250MB in size
      * @param file to upload
      * @param destinationFolder to upload the file into
-     * @return FQID of the uploaded file
+     * @return {@link OneDriveUploader.FQID FQID} of the uploaded file
      * @throws IOException if the request could not be executed
      * @throws GraphApiErrorException if the file could not be uploaded
      */
@@ -414,8 +413,8 @@ public class OneDriveUploader extends Uploader {
      * creates an upload session for a file in a destination folder on OneDrive.
      *
      * @param fileName of the file to upload
-     * @param destinationFolder as FQID
-     * @return String with the upload URL for the file
+     * @param destinationFolder as {@link OneDriveUploader.FQID FQID}
+     * @return {@link String} with the upload URL for the file
      * @throws IOException if there is an error executing the request
      * @throws GraphApiErrorException if the upload session was not created
      * @throws JSONException if the response does not contain the expected values
@@ -470,7 +469,7 @@ public class OneDriveUploader extends Uploader {
                     retryCount = 0;
                 } else if (uploadResponse.code() == 201 || uploadResponse.code() == 200) {
                     break;
-                } else { // TODO conflict after successful upload not handled
+                } else { // TODO 404 409 416
                     if (retryCount > MAX_RETRY_ATTEMPTS) {
                         Request cancelRequest = new Request.Builder().url(uploadURL).delete().build();
                         DriveBackup.httpClient.newCall(cancelRequest).execute().close();
@@ -535,7 +534,7 @@ public class OneDriveUploader extends Uploader {
         private final int length;
 
         /**
-         * Creates an instance of the {@code Range} object
+         * Creates an instance of the {@link OneDriveUploader.Range Range} object
          * @param start the index of the first byte
          * @param length of the range
          */
@@ -545,7 +544,7 @@ public class OneDriveUploader extends Uploader {
         }
 
         /**
-         * Creates an instance of the {@code Range} object
+         * Creates an instance of the {@link OneDriveUploader.Range Range} object
          * @param range in the format of {@code 000-000 or 000-}
          * @param maxLength to clamp the range to
          * @throws NumberFormatException if parseLong fails on range

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -339,9 +339,13 @@ public class OneDriveUploader extends Uploader {
      */
     @Nullable
     private FQID getFolder(@NotNull FQID root, @NotNull String folder) throws IOException, GraphApiErrorException {
-        for (JSONObject childItem : getChildren(root, "?select=name,id,parentReference,remoteItem")) {
-            String folderName = childItem.getString("name"); // TODO filter non folders
-            if (folder.equals(folderName)) {
+        String queryParams = "?select=name,id,folder,parentReference,remoteItem";
+        for (JSONObject childItem : getChildren(root, queryParams)) {
+            String itemName = childItem.getString("name");
+            if (folder.equals(itemName)) {
+                if (!childItem.has("folder")) {
+                    return null;
+                }
                 if (childItem.has("remoteItem")) {
                     childItem = childItem.getJSONObject("remoteItem");
                 }


### PR DESCRIPTION
folloup to #175 

got a bit bigger again with lots of refactoring
moving functionality into functions to improve local reasoning
reducing _(hidden)_ coupling/controlflow

other changes
handle more cases in/with normalizePath & concatPath
add GraphApiErrorException for better reporting of api errors
handle pagination for folders with 200+ items
explicitly handle more errors during upload