### PR TITLE
support daylight saving time

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/config/configSections/Advanced.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/config/configSections/Advanced.java
@@ -1,6 +1,7 @@
 package ratismal.drivebackup.config.configSections;
 
 import java.time.DateTimeException;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Locale;
 
@@ -18,16 +19,16 @@ public class Advanced {
     public final boolean suppressErrors;
     public final boolean debugEnabled;
     public final Locale dateLanguage;
-    public final ZoneOffset dateTimezone;
+    public final ZoneId dateTimezone;
     public final String fileSeparator;
 
     public Advanced(
-        boolean metricsEnabled, 
-        boolean updateCheckEnabled, 
+        boolean metricsEnabled,
+        boolean updateCheckEnabled,
         boolean suppressErrors,
         boolean debugEnabled,
-        Locale dateLanguage, 
-        ZoneOffset dateTimezone, 
+        Locale dateLanguage,
+        ZoneId dateTimezone,
         String fileSeparator
         ) {
             
@@ -48,9 +49,9 @@ public class Advanced {
         boolean suppressErrors = config.getBoolean("advanced.suppress-errors");
         boolean debugEnabled = config.getBoolean("advanced.debug");
         Locale dateLanguage = new Locale(config.getString("advanced.date-language"));
-        ZoneOffset dateTimezone;
+        ZoneId dateTimezone;
         try {
-            dateTimezone = ZoneOffset.of(config.getString("advanced.date-timezone"));
+            dateTimezone = ZoneId.of(config.getString("advanced.date-timezone"));
         } catch(DateTimeException e) {
             logger.log(intl("date-format-invalid"));
             //Fallback to UTC

--- a/DriveBackup/src/main/java/ratismal/drivebackup/handler/DebugCollector.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/handler/DebugCollector.java
@@ -1,7 +1,7 @@
 package ratismal.drivebackup.handler;
 
 import java.net.UnknownHostException;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -93,7 +93,7 @@ public class DebugCollector {
         private final boolean ftpEnabled;
         private final String ftpType;
 
-        private final ZoneOffset timezone;
+        private final ZoneId timezone;
 
         private ConfigInfo() {
             Config config = ConfigParser.getConfig();

--- a/DriveBackup/src/main/java/ratismal/drivebackup/plugin/Scheduler.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/plugin/Scheduler.java
@@ -1,7 +1,7 @@
 package ratismal.drivebackup.plugin;
 
 import java.time.DayOfWeek;
-import java.time.ZoneOffset;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.TextStyle;
@@ -54,7 +54,7 @@ public class Scheduler {
             SchedulerUtil.cancelTasks(backupTasks);
             backupDatesList.clear();
             for (BackupScheduleEntry entry : config.backupScheduling.schedule) {
-                ZoneOffset timezone = config.advanced.dateTimezone;
+                ZoneId timezone = config.advanced.dateTimezone;
                 for (DayOfWeek day : entry.days) {
                     ZonedDateTime previousOccurrence = ZonedDateTime.now(timezone)
                         .with(TemporalAdjusters.previous(day))


### PR DESCRIPTION
this changes the type of `dateTimezone` of the advanced config section to [ZoneId](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html) to support daylight saving time

_currently you need to update `date-timezone` manually to account for DST. with this, specifying a zone id will take care of it automatically_

very few changes where necessary as the previous [ZoneOffset](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneOffset.html) extends [ZoneId](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html) and the functions used with dateTimezone already took [ZoneId](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html) as arguments
[ZoneId.of](https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#of-java.lang.String-) parses both offsets and ids, so you can now specifiy either an offset or a zone in the `date-timezone` config field

the java docs reference the [IANA Time Zone Database](https://data.iana.org/time-zones/tzdb-2021a/zone1970.tab), but there is a nicer list from [Noda Time](https://nodatime.org/TimeZones)
a bunch of additional formats are also supported but the [wiki entry](https://github.com/MaxMaeder/DriveBackupV2/wiki/Advanced-Settings#date-timezone) should probably only mention `±HH:MM` and `{Area}/{City}` for simplicity