### PR TITLE
make @odata.count optional

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -381,7 +381,7 @@ public class OneDriveUploader extends Uploader {
                 }
                 JSONObject parsedResponse = new JSONObject(response.body().string());
                 JSONArray someChildren = parsedResponse.getJSONArray("value");
-                allChildren.ensureCapacity(parsedResponse.getInt("@odata.count"));
+                allChildren.ensureCapacity(parsedResponse.optInt("@odata.count", someChildren.length()));
                 for (int i = 0; i < someChildren.length(); i++) {
                     allChildren.add(someChildren.getJSONObject(i));
                 }


### PR DESCRIPTION
as it turns out the children api does not always include `@odata.count` in the response, im not sure when exactly that is the case,
but luckily its not mandatory: with this the length of the child item array is used instead if `@odata.count` is not available