### PR TITLE
update onedrive tokens to allow longer sessions

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/Authenticator.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/Authenticator.java
@@ -7,10 +7,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONObject;
-import ratismal.drivebackup.UploadThread.UploadLogger;
 import ratismal.drivebackup.handler.commandHandler.BasicCommands;
 import ratismal.drivebackup.plugin.DriveBackup;
-import ratismal.drivebackup.uploaders.googledrive.GoogleDriveUploader;
 import ratismal.drivebackup.util.Logger;
 import ratismal.drivebackup.util.MessageUtil;
 import ratismal.drivebackup.util.NetUtil;
@@ -198,12 +196,12 @@ public class Authenticator {
         BasicCommands.sendBriefBackupList(initiator);
     }
 
-    private static void saveRefreshToken(@NotNull AuthenticationProvider provider, String token) throws Exception {
+    public static void saveRefreshToken(@NotNull AuthenticationProvider provider, String token) throws IOException {
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("refresh_token", token);
-        FileWriter file = new FileWriter(provider.getCredStoreLocation());
-        file.write(jsonObject.toString());
-        file.close();
+        try (FileWriter file = new FileWriter(provider.getCredStoreLocation())) {
+            file.write(jsonObject.toString());
+        }
     }
 
     private static void enableBackupMethod(@NotNull AuthenticationProvider provider, Logger logger) {

--- a/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/uploaders/onedrive/OneDriveUploader.java
@@ -60,7 +60,7 @@ public class OneDriveUploader extends Uploader {
         this.logger = logger;
         setAuthProvider(AuthenticationProvider.ONEDRIVE);
         try {
-            refreshToken = Authenticator.getRefreshToken(AuthenticationProvider.ONEDRIVE);
+            refreshToken = Authenticator.getRefreshToken(getAuthProvider());
             retrieveNewAccessToken();
         } catch (Exception e) {
             MessageUtil.sendConsoleException(e);
@@ -76,7 +76,7 @@ public class OneDriveUploader extends Uploader {
      */
     private void retrieveNewAccessToken() throws Exception {
         RequestBody requestBody = new FormBody.Builder()
-            .add("client_id", Obfusticate.decrypt(AuthenticationProvider.ONEDRIVE.getClientId()))
+            .add("client_id", Obfusticate.decrypt(getAuthProvider().getClientId()))
             .add("scope", "offline_access Files.ReadWrite")
             .add("refresh_token", refreshToken)
             .add("grant_type", "refresh_token")
@@ -94,6 +94,7 @@ public class OneDriveUploader extends Uploader {
                 throw new IOException(String.format("%s : %s", error, description));
             }
             accessToken = parsedResponse.getString("access_token");
+            refreshToken = parsedResponse.getString("refresh_token");
         }
     }
 
@@ -158,7 +159,11 @@ public class OneDriveUploader extends Uploader {
     * Closes any remaining connections retrieveNewAccessToken
     */
     public void close() {
-        // nothing needs to be done
+        try {
+            Authenticator.saveRefreshToken(getAuthProvider(), refreshToken);
+        } catch (Exception e) {
+            MessageUtil.sendConsoleException(e);
+        }
     }
 
     /**


### PR DESCRIPTION
this makes the following two changes (and some adjacent cleanup)

**retrieving a new accesstoken for each upload:** `uploadFile` will now refresh the access token each call _(like the google drive uploader)_, before it was possible that the token expires before the last file upload was started _(token is valid for 1h)_

**update refreshtoken when retrieving a new accesstoken:** the uploader will now get an updated refresh_token in `retrieveNewAccessToken` and save it to disc on `close`, to ensure your refresh tokens remain valid for as long as possible _(as per ms docs)_
