### PR TITLE
strengthen uploadthread

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
@@ -47,14 +47,12 @@ import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import java.util.TreeMap;
 
 import static ratismal.drivebackup.config.Localization.intl;
@@ -563,11 +561,9 @@ public class UploadThread implements Runnable {
                 message = intl("backup-status-uploading");
                 break;
             case STARTING:
-                message = intl("backup-status-starting");
-                break;
+                return intl("backup-status-starting");
             case PRUNING:
-                message = intl("backup-status-pruning");
-                break;
+                return intl("backup-status-pruning");
             default:
                 return intl("backup-status-not-running");
         }
@@ -604,7 +600,7 @@ public class UploadThread implements Runnable {
      * Sets the time of the next interval-based backup to the current time + the configured interval.
      */
     public static void updateNextIntervalBackupTime() {
-        nextIntervalBackupTime = LocalDateTime.now().plus(ConfigParser.getConfig().backupStorage.delay, ChronoUnit.MINUTES);
+        nextIntervalBackupTime = LocalDateTime.now().plusMinutes(ConfigParser.getConfig().backupStorage.delay);
     }
 
     public static boolean wasLastBackupSuccessful() {


### PR DESCRIPTION
this has a few changes to make `UploadThread` more resilient

`getBackupStatus` will now directly return strings that do not need any replacements. in the past this function has often caused exceptions when called while `UploadThread` was in an inconsistent state, this reduces to chance of an exception.

`run` has been split into `run` and `run_internal`.
`run_internal` has the bulk of the actual upload logic.
`run` will wrap `run_internal` in a try block to make sure that `lastBackupSuccessful` and `backupStatus` are properly set when encountering an exception or returning early. both of those have caused problems in the past.
it also prevents `UploadThread` getting into an broken state with `local-keep-count: 0` _(resulting in an exception on further actions)_