### PR TITLE
print out stack trace if backup local fails with generic exception

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
@@ -381,6 +381,7 @@ public class UploadThread implements Runnable {
             return;
         } catch (Exception exception) {
             logger.log(intl("backup-local-failed"));
+            MessageUtil.sendConsoleException(exception);
             return;
         }
         locationsToBePruned.put(location, formatter);


### PR DESCRIPTION
print out stack trace if backup local fails with generic exception

it uses the MessageUtil.sendConsoleException so it respects the suppress errors config option