### PR TITLE
New Feature: dynamically replacing files during packaging

### DIFF
--- a/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/UploadThread.java
@@ -257,7 +257,7 @@ public class UploadThread implements Runnable {
             backupBackingUp++;
             for (Path folder : set.location.getPaths()) {
                 if (set.create) {
-                    makeBackupFile(folder.toString(), set.formatter, Arrays.asList(set.blacklist));
+                    makeBackupFile(folder.toString(), set.formatter, Arrays.asList(set.blacklist), set.replace);
                 }
             }
         }
@@ -381,11 +381,11 @@ public class UploadThread implements Runnable {
      * @param formatter save format configuration
      * @param blackList a configured blacklist (with globs)
      */
-    private void makeBackupFile(String location, LocalDateTimeFormatter formatter, List<String> blackList) {
+    private void makeBackupFile(String location, LocalDateTimeFormatter formatter, List<String> blackList, Map<String, String> replace) {
         logger.info(intl("backup-local-file-start"), "location", location);
         try {
             ServerUtil.setAutoSave(false);
-            fileUtil.makeBackup(location, formatter, blackList);
+            fileUtil.makeBackup(location, formatter, blackList, replace);
         } catch (AbsolutePathException exception) {
             logger.log(intl("backup-failed-absolute-path"));
             return;
@@ -524,7 +524,8 @@ public class UploadThread implements Runnable {
             new PathBackupLocation("external-backups" + "/" + tempFolderName),
             externalBackup.format,
             true,
-            new String[0]
+            new String[0],
+            new HashMap<>()
         );
         backupList.add(backup);
         if (ftpUploader.isErrorWhileUploading()) {
@@ -569,7 +570,8 @@ public class UploadThread implements Runnable {
             new PathBackupLocation("external-backups" + "/" + tempFolderName),
             externalBackup.format,
             true,
-            new String[0]
+            new String[0],
+            new HashMap<>()
         );
         backupList.add(backup);
         if (mysqlUploader.isErrorWhileUploading()) {

--- a/DriveBackup/src/main/java/ratismal/drivebackup/config/configSections/BackupList.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/config/configSections/BackupList.java
@@ -12,6 +12,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,18 +65,21 @@ public class BackupList {
         public final LocalDateTimeFormatter formatter;
         public final boolean create;
         public final String[] blacklist;
+        public final Map<String, String> replace;
         
         public BackupListEntry(
             BackupLocation location,
             LocalDateTimeFormatter formatter, 
             boolean create, 
-            String[] blacklist
+            String[] blacklist,
+            Map<String, String> replace
             ) {
 
             this.location = location;
             this.formatter = formatter;
             this.create = create;
             this.blacklist = blacklist;
+            this.replace = replace;
         }
     }
 
@@ -134,7 +139,23 @@ public class BackupList {
                     logger.log(intl("backup-list-blacklist-invalid"), ENTRY, entryIndex);
                 }
             }
-            list.add(new BackupListEntry(location, formatter, create, blacklist));
+            Map<String, String> replace = new LinkedHashMap<>();
+            if (rawListEntry.containsKey("path") && rawListEntry.containsKey("replace")) {
+                try {
+                    List<Map<String, String>> replaceList = (List<Map<String, String>>) rawListEntry.get("replace");
+                    for (Map<String, String> replaceListEntry : replaceList) {
+                        if (replaceListEntry.containsKey("file") && replaceListEntry.containsKey("with")) {
+                            replace.put(replaceListEntry.get("file"), replaceListEntry.get("with"));
+                        } else {
+                            replace.clear();
+                            throw new IllegalArgumentException();
+                        }
+                    }
+                } catch (IllegalArgumentException | ClassCastException e) {
+                    logger.log(intl("backup-list-replace-invalid"), ENTRY, entryIndex);
+                }
+            }
+            list.add(new BackupListEntry(location, formatter, create, blacklist, replace));
         }
         return new BackupList(list.toArray(new BackupListEntry[0]));
     }

--- a/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
+++ b/DriveBackup/src/main/java/ratismal/drivebackup/util/FileUtil.java
@@ -19,7 +19,9 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -70,7 +72,7 @@ public class FileUtil {
      * @param blacklistGlobs a list of glob patterns of files/folders to not include in the backup.
      * @throws Exception
      */
-    public void makeBackup(@NotNull String location, LocalDateTimeFormatter formatter, List<String> blacklistGlobs) throws Exception {
+    public void makeBackup(@NotNull String location, LocalDateTimeFormatter formatter, List<String> blacklistGlobs, Map<String, String> replace) throws Exception {
         Config config = ConfigParser.getConfig();
         if (location.charAt(0) == '/') {
             throw new AbsolutePathException("Location cannot start with a slash");
@@ -104,6 +106,41 @@ public class FileUtil {
                     "glob-pattern", globPattern);
             }
         }
+        Map<String, String> checkedReplace = new HashMap<>();
+        if (Files.isDirectory(Paths.get(location))) {
+            Map<Path, String> fileListPaths = fileList.getList().stream()
+                .collect(Collectors.toMap(Paths::get, s -> s, (a, b) -> a));
+            replace.forEach((key, value) -> {
+                if (isUnsafeRelativePath(key) || isUnsafeRelativePath(value)) {
+                    logger.info(intl("backup-list-replace-unsafe-path"), "file-path", key + " -> " + value);
+                    return;
+                }
+                File file = new File(location + "/" + key);
+                File with = new File(location + "/" + value);
+                if (!isWithinLocation(location, with)) {
+                    logger.info(intl("local-backup-replace-escapes-location"), "file-path", key + " -> " + value, "location", location);
+                    return;
+                }
+                Path filePath = Paths.get(key);
+                Path withPath = Paths.get(value);
+                String matched = fileListPaths.get(filePath);
+                if (file.isFile() && with.isFile() && matched != null) {
+                    if (isWithinLocation(config.backupStorage.localDirectory, with)) {
+                        fileList.incFilesInBackupFolder();
+                        return;
+                    }
+                    if (checkedReplace.containsKey(matched)) {
+                        logger.info(intl("local-backup-replace-duplicate"), "file-path", matched);
+                        return;
+                    }
+                    checkedReplace.put(matched, withPath.toString());
+                    return;
+                }
+                logger.info(intl("local-backup-replace-skipped"), "file-path", file.getPath(), "with-path", with.getPath());
+            });
+        } else if (!replace.isEmpty()) {
+            logger.info(intl("local-backup-replace-not-folder"), "location", location);
+        }
         int filesInBackupFolder = fileList.getFilesInBackupFolder();
         if (filesInBackupFolder > 0) {
             logger.info(
@@ -115,7 +152,7 @@ public class FileUtil {
             String lastFolderName = location.substring(lastSeparatorIndex + 1);
             fileName = fileName.replace(NAME_KEYWORD, lastFolderName);
         }
-        zipIt(location, path.getPath() + "/" + fileName, fileList);
+        zipIt(location, path.getPath() + "/" + fileName, fileList, checkedReplace);
     }
 
     /**
@@ -175,7 +212,7 @@ public class FileUtil {
      * @param outputFilePath the path of the folder to put it in
      * @param fileList file to include in the zip
      */
-    private void zipIt(String inputFolderPath, String outputFilePath, BackupFileList fileList) throws Exception {
+    private void zipIt(String inputFolderPath, String outputFilePath, BackupFileList fileList, Map<String, String> replace) throws Exception {
         byte[] buffer = new byte[1024];
         FileOutputStream fileOutputStream;
         ZipOutputStream zipOutputStream = null;
@@ -189,7 +226,7 @@ public class FileUtil {
             zipOutputStream.setLevel(ConfigParser.getConfig().backupStorage.zipCompression);
             for (String file : fileList.getList()) {
                 ZipEntry entry = new ZipEntry(formattedInputFolderPath + "/" + file);
-                String filePath = inputFolderPath + "/" + file;
+                String filePath = inputFolderPath + "/" + replace.getOrDefault(file, file);
                 BasicFileAttributes fileAttributes = null;
                 try {
                     fileAttributes = Files.readAttributes(Paths.get(filePath), BasicFileAttributes.class);
@@ -322,6 +359,31 @@ public class FileUtil {
     @Contract (pure = true)
     private static String escapeBackupLocation(@NotNull String location) {
         return location.replace("../", "");
+    }
+
+    private static boolean isUnsafeRelativePath(@NotNull String path) {
+        if (path.isEmpty()) return true;
+        Path p = Paths.get(path);
+        if (p.isAbsolute()) return true;
+        for (Path seg : p) {
+            if (seg.toString().equals("..")) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Whether the target file's real (symlink-resolved) path is still contained within location.
+     * Guards against a symlink inside location pointing outside of it, which a purely
+     * string-based check like {@link #isUnsafeRelativePath} cannot detect.
+     */
+    private static boolean isWithinLocation(String location, File target) {
+        try {
+            Path root = new File(location).getCanonicalFile().toPath();
+            Path real = target.getCanonicalFile().toPath();
+            return real.startsWith(root);
+        } catch (IOException e) {
+            return false;
+        }
     }
 
     /**

--- a/DriveBackup/src/main/resources/intl.yml
+++ b/DriveBackup/src/main/resources/intl.yml
@@ -17,6 +17,8 @@ backup-failed-absolute-path: |-
 backup-file-upload-complete: 'Upload(s) for file "<file-name>" complete'
 backup-file-upload-start: 'Starting upload(s) for file "<file-name>"'
 backup-forced: "Forcing a backup"
+backup-list-replace-invalid: "Replace invalid in backup entry <entry>, leaving blank"
+backup-list-replace-unsafe-path: 'Skipping unsafe replace path "<file-path>", it must be a relative path without ".."'
 backup-list-blacklist-invalid: "Blacklist invalid in backup entry <entry>, leaving blank"
 backup-list-format-invalid: "Format invalid, skipping backup list entry <entry>"
 backup-list-glob-invalid: "Glob invalid, skipping backup list entry <entry>"
@@ -198,6 +200,10 @@ local-backup-limit-reached: "There are <backup-count> file(s) which exceeds the
 local-backup-no-limit: "Local backup limit is set to 0, skipping pruning"
 local-backup-pruning-complete: 'Local backup pruning complete for "<location>"'
 local-backup-pruning-start: 'Pruning local backups for "<location>"'
+local-backup-replace-duplicate: 'Multiple replace entries target "<file-path>" in the backup, using the first one'
+local-backup-replace-escapes-location: 'Skipping replace of "<file-path>", it resolves outside of location "<location>" (possibly via a symlink)'
+local-backup-replace-not-folder: 'Ignoring replace for "<location>", it must be a folder to use replace'
+local-backup-replace-skipped: 'Skipping replace of "<file-path>" with "<with-path>", make sure both files exist and "<file-path>" is not blacklisted'
 local-keep-count-invalid: "Inputted local keep count invalid, using default"
 local-save-directory-not-relative: "Local save directory is not relative, making relative to server directory"
 location-empty: "Location <location> is empty, skipping"


### PR DESCRIPTION
This feature only applies to Path-type backups (not Glob or single-file backups). It allows dynamically replacing files inside the zip archive during packaging.

One application on my server: using a custom-built Java agent to intercept the H2 database connection URL, then writing a plugin that listens for DriveBackupV2's backup events, connecting to the H2 database ahead of time to export the data. This works great for backing up databases used by plugins like LuckPerms, and avoids the issue on Windows where some local databases can't be backed up due to exclusive file locks. Of course, there's likely more to explore with this feature.

Usage:
```
...
blacklist:
  - ...
replace:
  - file: <file to be replaced>
    with: <replace with this file>
  - file: <another file>
    with: <replace with>
```
Under `replace`, each entry defines a pair: file is the path (relative to the backup source) of the file that would normally be included in the zip, and with is the path to the file that should be packaged in its place. Multiple pairs can be listed to replace several files in the same backup.